### PR TITLE
refactor: modularize prayer page

### DIFF
--- a/app/prayer/page.js
+++ b/app/prayer/page.js
@@ -1,202 +1,21 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import Image from "next/image";
-import {
-  Accordion,
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from "@/components/ui/accordion";
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle } from "lucide-react";
 import clsx from "clsx";
+import { Stepper } from "@/components/prayer/stepper";
+import { StepCard } from "@/components/prayer/step-card";
+import { RakaaDisplay } from "@/components/prayer/rakaa-display";
+import { MetaBlock } from "@/components/prayer/meta-block";
 import hanbaliPrayerData from '@/content/howtopray.json';
 import hanafiPrayerData from '@/content/howtoprayhanifi.json';
 import shafiiPrayerData from '@/content/howtoprayshafii.json';
 
-/**
- * Utility: simple horizontal stepper to visualise rakʿāt progression
- */
-const Stepper = ({ total, current }) => (
-  <div className="flex items-center justify-center gap-4 mb-8 select-none">
-    {Array.from({ length: total }).map((_, idx) => {
-      const done = idx < current;
-      const active = idx === current;
-      return (
-        <div key={idx} className="flex items-center gap-2">
-          <motion.div
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ type: "spring", stiffness: 260, damping: 20 }}
-            className={clsx(
-              "w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold border",
-              done && "bg-emerald-600 text-white border-emerald-600",
-              active && "bg-emerald-500/20 text-emerald-700 border-emerald-500",
-              !done && !active && "bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300"
-            )}
-          >
-            {done ? <CheckCircle size={18} /> : idx + 1}
-          </motion.div>
-          {idx < total - 1 && <div className="w-8 h-px bg-gray-300 dark:bg-gray-600" />}
-        </div>
-      );
-    })}
-  </div>
-);
-
-/**
- * Displays an individual prayer step inside a Card component
- */
-const PrayerStep = ({ step }) => (
-  <Card as={motion.div} initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} layout>
-    <CardHeader className="flex flex-row items-start justify-between gap-2">
-      <h3 className="text-base font-medium capitalize">
-        {step.id.replace(/_/g, " ")}
-      </h3>
-      {step.type && (
-        <Badge variant="secondary" className="whitespace-nowrap capitalize">
-          {step.type}
-        </Badge>
-      )}
-    </CardHeader>
-    <CardContent className="space-y-3">
-      {step.arabic && (
-        <p dir="rtl" className="font-arabic text-xl leading-loose text-right">
-          {step.arabic}
-        </p>
-      )}
-      {step.description && <p className="text-[15px] leading-relaxed">{step.description}</p>}
-      {step.min_reps && (
-        <p className="text-sm text-muted-foreground">
-          Repetitions: {step.min_reps}
-          {step.pref_reps ? ` (preferably ${step.pref_reps})` : ""}
-        </p>
-      )}
-      {step.transliteration && (
-        <p className="text-sm text-muted-foreground italic">
-          {step.transliteration}
-        </p>
-      )}
-      {step.evidence && (
-        <details className="text-sm cursor-pointer select-none">
-          <summary className="mb-1 font-medium">Evidence</summary>
-          <ul className="list-disc ml-5 space-y-1">
-            {step.evidence.map((src, i) => (
-              <li key={i}>{src}</li>
-            ))}
-          </ul>
-        </details>
-      )}
-      {step.sources && (
-        <details className="text-sm cursor-pointer select-none">
-          <summary className="mb-1 font-medium">Sources</summary>
-          <ul className="list-disc ml-5 space-y-1">
-            {step.sources.map((src, i) => (
-              <li key={i}>{src}</li>
-            ))}
-          </ul>
-        </details>
-      )}
-    </CardContent>
-  </Card>
-);
-
-/**
- * Shows steps of a single Rakʿa inside an Accordion item
- */
-const RakaaDisplay = ({ rakaa, defaultOpen }) => (
-  <AccordionItem value={`rakaa-${rakaa.number}`} className="border-none">
-    <AccordionTrigger className="rounded-lg bg-gray-100 dark:bg-gray-800 px-4 py-3 mb-2 hover:bg-gray-200 dark:hover:bg-gray-700 text-left w-full">
-      <span className="text-lg font-semibold">Rakʿa {rakaa.number}</span>
-    </AccordionTrigger>
-    <AccordionContent className="space-y-4 pl-1 pr-1">
-      {rakaa.exceptions && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-400 dark:border-yellow-600 rounded-md"
-        >
-          <p className="font-medium mb-1 text-sm">
-            Exceptions from Rakʿa {rakaa.clone_rakʿah_of}:
-          </p>
-          <ul className="list-disc list-inside space-y-1 text-sm">
-            {rakaa.exceptions.map((ex, idx) => (
-              <li key={idx}>{ex}</li>
-            ))}
-          </ul>
-        </motion.div>
-      )}
-      <AnimatePresence initial={false}>
-        {rakaa.steps?.map((step, idx) => (
-          <PrayerStep key={`${rakaa.number}-${idx}`} step={step} />
-        ))}
-      </AnimatePresence>
-    </AccordionContent>
-  </AccordionItem>
-);
-
-/**
- * Displays a Hanafi prayer step inside a Card component
- */
-const HanafiPrayerStep = ({ step }) => (
-  <Card as={motion.div} initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} layout>
-    <CardHeader className="flex flex-row items-start justify-between gap-2">
-      <h3 className="text-base font-medium capitalize">
-        {step.id.replace(/_/g, " ")}
-      </h3>
-      {step.type && (
-        <Badge variant="secondary" className="whitespace-nowrap capitalize">
-          {step.type}
-        </Badge>
-      )}
-    </CardHeader>
-    <CardContent className="space-y-3">
-      {step.arabic && (
-        <p dir="rtl" className="font-arabic text-xl leading-loose text-right">
-          {step.arabic}
-        </p>
-      )}
-      {step.description && <p className="text-[15px] leading-relaxed">{step.description}</p>}
-      {step.transliteration && (
-        <p className="text-sm text-muted-foreground italic">
-          {step.transliteration}
-        </p>
-      )}
-      {step.sources && (
-        <details className="text-sm cursor-pointer select-none">
-          <summary className="mb-1 font-medium">Sources</summary>
-          <ul className="list-disc ml-5 space-y-1">
-            {step.sources.map((src, i) => (
-              <li key={i}>{src}</li>
-            ))}
-          </ul>
-        </details>
-      )}
-    </CardContent>
-  </Card>
-);
-
-/**
- * Meta‑blocks (Final Tashahhud & Taslīm) share similar UI
- */
-const MetaBlock = ({ title, rows }) => (
-  <Card as={motion.section} initial={{ y: 20, opacity: 0 }} whileInView={{ y: 0, opacity: 1 }} viewport={{ once: true }} className="mb-10">
-    <CardHeader>
-      <h2 className="text-xl font-bold">{title}</h2>
-    </CardHeader>
-    <CardContent className="space-y-2">
-      {rows.map(({ label, value }, idx) => (
-        <p key={idx} className="text-sm">
-          <span className="font-medium mr-1">{label}:</span>
-          {value}
-        </p>
-      ))}
-    </CardContent>
-  </Card>
-);
+// Components extracted for clarity
 
 /**
  * Main Prayer Page
@@ -428,7 +247,7 @@ export default function PrayerPage() {
 
           <div className="space-y-6">
             {hanafiPrayerData.steps.map((step) => (
-              <HanafiPrayerStep key={step.id} step={step} />
+              <StepCard key={step.id} step={step} showEvidence={false} showReps={false} />
             ))}
           </div>
         </div>
@@ -443,7 +262,7 @@ export default function PrayerPage() {
 
           <div className="space-y-6">
             {shafiiPrayerData.steps.map((step) => (
-              <HanafiPrayerStep key={step.id} step={step} />
+              <StepCard key={step.id} step={step} showEvidence={false} showReps={false} />
             ))}
           </div>
 

--- a/components/prayer/meta-block.tsx
+++ b/components/prayer/meta-block.tsx
@@ -1,0 +1,30 @@
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+
+interface Row {
+  label: string
+  value: string
+}
+
+interface MetaBlockProps {
+  title: string
+  rows: Row[]
+}
+
+export function MetaBlock({ title, rows }: MetaBlockProps) {
+  return (
+    <Card as={motion.section} initial={{ y: 20, opacity: 0 }} whileInView={{ y: 0, opacity: 1 }} viewport={{ once: true }} className="mb-10">
+      <CardHeader>
+        <h2 className="text-xl font-bold">{title}</h2>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {rows.map(({ label, value }, idx) => (
+          <p key={idx} className="text-sm">
+            <span className="font-medium mr-1">{label}:</span>
+            {value}
+          </p>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/prayer/rakaa-display.tsx
+++ b/components/prayer/rakaa-display.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { AnimatePresence } from 'framer-motion'
+import { AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion'
+import { motion } from 'framer-motion'
+import { StepCard } from './step-card'
+
+interface Rakaa {
+  number: number
+  steps?: any[]
+  exceptions?: string[]
+  clone_rakʿah_of?: number
+}
+
+interface RakaaDisplayProps {
+  rakaa: Rakaa
+}
+
+export function RakaaDisplay({ rakaa }: RakaaDisplayProps) {
+  return (
+    <AccordionItem value={`rakaa-${rakaa.number}`} className="border-none">
+      <AccordionTrigger className="rounded-lg bg-gray-100 dark:bg-gray-800 px-4 py-3 mb-2 hover:bg-gray-200 dark:hover:bg-gray-700 text-left w-full">
+        <span className="text-lg font-semibold">Rakʿa {rakaa.number}</span>
+      </AccordionTrigger>
+      <AccordionContent className="space-y-4 pl-1 pr-1">
+        {rakaa.exceptions && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-400 dark:border-yellow-600 rounded-md"
+          >
+            <p className="font-medium mb-1 text-sm">Exceptions from Rakʿa {rakaa.clone_rakʿah_of}:</p>
+            <ul className="list-disc list-inside space-y-1 text-sm">
+              {rakaa.exceptions.map((ex, idx) => (
+                <li key={idx}>{ex}</li>
+              ))}
+            </ul>
+          </motion.div>
+        )}
+        <AnimatePresence initial={false}>
+          {rakaa.steps?.map((step, idx) => (
+            <StepCard key={`${rakaa.number}-${idx}`} step={step} />
+          ))}
+        </AnimatePresence>
+      </AccordionContent>
+    </AccordionItem>
+  )
+}

--- a/components/prayer/step-card.tsx
+++ b/components/prayer/step-card.tsx
@@ -1,0 +1,73 @@
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+interface Step {
+  id: string
+  type?: string
+  arabic?: string
+  description?: string
+  transliteration?: string
+  min_reps?: number
+  pref_reps?: number
+  evidence?: string[]
+  sources?: string[]
+}
+
+interface StepCardProps {
+  step: Step
+  showEvidence?: boolean
+  showReps?: boolean
+}
+
+export function StepCard({ step, showEvidence = true, showReps = true }: StepCardProps) {
+  return (
+    <Card as={motion.div} initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} layout>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <h3 className="text-base font-medium capitalize">{step.id.replace(/_/g, ' ')}</h3>
+        {step.type && (
+          <Badge variant="secondary" className="whitespace-nowrap capitalize">
+            {step.type}
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {step.arabic && (
+          <p dir="rtl" className="font-arabic text-xl leading-loose text-right">
+            {step.arabic}
+          </p>
+        )}
+        {step.description && <p className="text-[15px] leading-relaxed">{step.description}</p>}
+        {showReps && step.min_reps && (
+          <p className="text-sm text-muted-foreground">
+            Repetitions: {step.min_reps}
+            {step.pref_reps ? ` (preferably ${step.pref_reps})` : ''}
+          </p>
+        )}
+        {step.transliteration && (
+          <p className="text-sm text-muted-foreground italic">{step.transliteration}</p>
+        )}
+        {showEvidence && step.evidence && (
+          <details className="text-sm cursor-pointer select-none">
+            <summary className="mb-1 font-medium">Evidence</summary>
+            <ul className="list-disc ml-5 space-y-1">
+              {step.evidence.map((src, i) => (
+                <li key={i}>{src}</li>
+              ))}
+            </ul>
+          </details>
+        )}
+        {step.sources && (
+          <details className="text-sm cursor-pointer select-none">
+            <summary className="mb-1 font-medium">Sources</summary>
+            <ul className="list-disc ml-5 space-y-1">
+              {step.sources.map((src, i) => (
+                <li key={i}>{src}</li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/prayer/stepper.tsx
+++ b/components/prayer/stepper.tsx
@@ -1,0 +1,38 @@
+import { motion } from 'framer-motion'
+import clsx from 'clsx'
+import { CheckCircle } from 'lucide-react'
+
+interface StepperProps {
+  total: number
+  current: number
+}
+
+export function Stepper({ total, current }: StepperProps) {
+  return (
+    <div className="flex items-center justify-center gap-4 mb-8 select-none">
+      {Array.from({ length: total }).map((_, idx) => {
+        const done = idx < current
+        const active = idx === current
+        return (
+          <div key={idx} className="flex items-center gap-2">
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+              className={clsx(
+                'w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold border',
+                done && 'bg-emerald-600 text-white border-emerald-600',
+                active && 'bg-emerald-500/20 text-emerald-700 border-emerald-500',
+                !done && !active &&
+                  'bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
+              )}
+            >
+              {done ? <CheckCircle size={18} /> : idx + 1}
+            </motion.div>
+            {idx < total - 1 && <div className="w-8 h-px bg-gray-300 dark:bg-gray-600" />}
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- split prayer page UI into reusable components
- simplify main `page.js` logic

## Testing
- `ruff check`
- `black --check .`
- `pytest` *(fails: command not found)*
- `mypy .`
- `pyright`
- `CI=true npm run lint`
- `CI=true npm run test`